### PR TITLE
Add form validation for email and fix linter error

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,7 @@
     <form id="contact-form" action="https://formspree.io/f/xgebdkkr" method="post">
       <input class="form-elm form-input" id="name" type="text" maxlength="30" placeholder="Full name" name="name" required>
       <input class="form-elm form-input" id="email" type="email" placeholder="Email address" name="email" required>
+      <small></small>
       <textarea class="form-elm" id="txt-area" name="message" cols="30" rows="10" maxlength="500" placeholder="Write me something..." required></textarea>
       <button id="submit-btn" class="btn" type="submit">Get in touch</button>
     </form>

--- a/index.js
+++ b/index.js
@@ -313,3 +313,26 @@ Array.from(projectCards).forEach((specificCard, index) => {
     });
   });
 });
+
+// ****************************** Email Validation ****************************** //
+
+// Regex matches an email address with only lower-case letters and underscores,
+// and allows for ornly one period enywhere between the first and last character
+// of the personal pard of the address;
+
+const regex = /^[a-z0-9_]+(\.[a-z0-9_]+)?@+[a-z0-9_]+(\.[a-z0-9_]+)*\.[a-z0-9_]+$/;
+const form = document.getElementById('contact-form');
+const email = form.querySelector('input[type="email"]');
+const msg = form.querySelector('small');
+
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+
+  const emailAddress = email.value.trim();
+
+  if (!regex.test(emailAddress)) {
+    msg.innerText = 'Please enter a correct email address format';
+  } else {
+    form.submit();
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -353,7 +353,7 @@
   color: #979493;
 }
 
-small{
+small {
   font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 0.9rem;

--- a/styles.css
+++ b/styles.css
@@ -353,6 +353,14 @@
   color: #979493;
 }
 
+small{
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: #db4949;
+  align-self: flex-start;
+}
+
 .form-elm {
   width: 100%;
   border: none;


### PR DESCRIPTION
This pull request will introduce simple client-side form validation for the email. It will check to see that the email address
- Only contains lower case letters, numbers, and underscores
- Does not start or end with a period
- Has only one period between the first and last character of the personal part of the address